### PR TITLE
Update sample_complete.js

### DIFF
--- a/Chapter04/Documentation/answers/lib/sample_complete.js
+++ b/Chapter04/Documentation/answers/lib/sample_complete.js
@@ -52,7 +52,7 @@ function CreateOrder(purchase) {
  * @transaction
  */
 function Buy(purchase) {
-    if (purchase.order.status = JSON.stringify(orderStatus.Created))
+    if (purchase.order.status == JSON.stringify(orderStatus.Created))
     {
         purchase.order.buyer = purchase.buyer;
         purchase.order.seller = purchase.seller;
@@ -70,7 +70,7 @@ function Buy(purchase) {
  * @transaction
  */
 function OrderCancel(purchase) {
-    if ((purchase.order.status = JSON.stringify(orderStatus.Created)) || (purchase.order.status = JSON.stringify(orderStatus.Bought)))
+    if ((purchase.order.status == JSON.stringify(orderStatus.Created)) || (purchase.order.status == JSON.stringify(orderStatus.Bought)))
     {
         purchase.order.buyer = purchase.buyer;
         purchase.order.seller = purchase.seller;
@@ -88,7 +88,7 @@ function OrderCancel(purchase) {
  * @transaction
  */
 function OrderFromSupplier(purchase) {
-    if (purchase.order.status = JSON.stringify(orderStatus.Bought))
+    if (purchase.order.status == JSON.stringify(orderStatus.Bought))
     {
         purchase.order.provider = purchase.provider;
         purchase.order.ordered = new Date().toISOString();
@@ -105,7 +105,7 @@ function OrderFromSupplier(purchase) {
  * @transaction
  */
 function RequestShipping(purchase) {
-    if (purchase.order.status = JSON.stringify(orderStatus.Ordered))
+    if (purchase.order.status == JSON.stringify(orderStatus.Ordered))
     {
         purchase.order.shipper = purchase.shipper;
         purchase.order.requestShipment = new Date().toISOString();
@@ -122,7 +122,7 @@ function RequestShipping(purchase) {
  * @transaction
  */
 function Delivering(purchase) {
-    if ((purchase.order.status = JSON.stringify(orderStatus.ShipRequest)) || (JSON.parse(purchase.order.status).code = orderStatus.Delivering.code))
+    if ((purchase.order.status == JSON.stringify(orderStatus.ShipRequest)) || (JSON.parse(purchase.order.status).code == orderStatus.Delivering.code))
     {
         purchase.order.delivering = new Date().toISOString();
         var _status = orderStatus.Delivering;
@@ -140,7 +140,7 @@ function Delivering(purchase) {
  * @transaction
  */
 function Deliver(purchase) {
-    if ((purchase.order.status = JSON.stringify(orderStatus.ShipRequest)) || (JSON.parse(purchase.order.status).code = orderStatus.Delivering.code))
+    if ((purchase.order.status == JSON.stringify(orderStatus.ShipRequest)) || (JSON.parse(purchase.order.status).code == orderStatus.Delivering.code))
     {
         purchase.order.delivered = new Date().toISOString();
         purchase.order.status = JSON.stringify(orderStatus.Delivered);


### PR DESCRIPTION
Assume conditionals such as `if (purchase.order.status = JSON.stringify(orderStatus.Created))` will be treated as assignment statements rather than a conditional resulting in a boolean value appropriate for an `if` statement.  Proposing this change