### PR TITLE
Added an empty line after licence statement so as to not break the license-check test

### DIFF
--- a/Chapter04/Documentation/answers/lib/sample_complete.js
+++ b/Chapter04/Documentation/answers/lib/sample_complete.js
@@ -11,6 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 var orderStatus = {
     Created: {code: 1, text: 'Order Created'},
     Bought: {code: 2, text: 'Order Purchased'},


### PR DESCRIPTION
Currently `nom test` fails because of a missing empty line after the licence test in `sample_complete.js`